### PR TITLE
Fix bucket variable name in ffmpeg Lambda

### DIFF
--- a/lambda_functions/generate-audio-and-upload-to-s3-ffmpeg.py
+++ b/lambda_functions/generate-audio-and-upload-to-s3-ffmpeg.py
@@ -22,7 +22,7 @@ s3_client = boto3.client('s3')
 BUCKET_NAME = 'sageinsightsai-audio'
 
 # for ffmpeg from s3
-FMPEG_BUCKET_NAME = 'lambda-dependencies-sageinsightsai'  # Replace with your actual S3 bucket name
+FFMPEG_BUCKET_NAME = 'lambda-dependencies-sageinsightsai'  # Replace with your actual S3 bucket name
 FFMPEG_KEY = 'ffmpeg'
 
 def download_ffmpeg():


### PR DESCRIPTION
## Summary
- fix typo for `FFMPEG_BUCKET_NAME` in the FFmpeg lambda script

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a9ea10a1883278bb69431b8e87ec5